### PR TITLE
Card Design Tweaks + Toolkit Doc Updates

### DIFF
--- a/src/develop/components/ContentCardDoc.js
+++ b/src/develop/components/ContentCardDoc.js
@@ -4,6 +4,7 @@ var React = require('react');
 var jsxToString = require('jsx-to-string');
 var DocsArticle = require('../../DocsArticle');
 var ContentCard = require('../../modules/ContentCard');
+var Box = require('grommet/components/Box');
 var Tiles = require('grommet/components/Tiles');
 var Heading = require('grommet/components/Heading');
 var SocialTwitterIcon = require('grommet/components/icons/base/SocialTwitter');
@@ -35,43 +36,49 @@ var ContentCardDoc = React.createClass({
 
   render: function() {
     var simpleContentCard = (
-      <ContentCard
-        thumbnail="/docs/img/Case_Study_image.png"
-        overline="Featured Post"
-        heading="The Key Steps to Reducing Software Spend"
-        description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
-      />
+      <Box colorIndex="light-2">
+        <ContentCard
+          thumbnail="/docs/img/Case_Study_image.png"
+          overline="Featured Post"
+          heading="The Key Steps to Reducing Software Spend"
+          description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
+        />
+      </Box>
     );
 
     var linkContentCard = (
-      <ContentCard
-        contentPlacement="bottom"
-        thumbnail="/docs/img/Case_Study_image.png"
-        overline="Featured Post"
-        heading="The Key Steps to Reducing Software Spend"
-        description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
-        link="#"
-      />
+      <Box colorIndex="light-2">
+        <ContentCard
+          contentPlacement="bottom"
+          thumbnail="/docs/img/Case_Study_image.png"
+          overline="Featured Post"
+          heading="The Key Steps to Reducing Software Spend"
+          description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
+          link="#"
+        />
+      </Box>
     );
 
     var videoContentCard = (
-      <ContentCard
-        direction="row"
-        thumbnail="/docs/img/Video_image.png"
-        overline="Video - 4:27"
-        heading="Foundation Paraguay Empowers Microbusinesses"
-        description="See how Hewlett Packard Enterprise delivers mobile solutions to improve quality of life and help eliminate poverty in South America."
-        video={{
-          source: 'video/test.mp4',
-          type: 'mp4'
-        }}
-      />
+      <Box colorIndex="light-2">
+        <ContentCard
+          direction="row"
+          thumbnail="/docs/img/Video_image.png"
+          overline="Video - 4:27"
+          heading="Foundation Paraguay Empowers Microbusinesses"
+          description="See how Hewlett Packard Enterprise delivers mobile solutions to improve quality of life and help eliminate poverty in South America."
+          video={{
+            source: 'video/test.mp4',
+            type: 'mp4'
+          }}
+        />
+      </Box>
     );
 
     var socialFeedCard = (
       <ContentCard
         direction="column"
-        overline="Featured Post"
+        overline="Social"
         socialIcon={<SocialTwitterIcon />}
         link="http://www.twitter.com">
         <Heading tag="h2">Protect Your Digital Enterprise ipsum lorem dolores aeat el</Heading>
@@ -98,15 +105,15 @@ var ContentCardDoc = React.createClass({
     );
 
     var socialCards = (
-      <Tiles size="large">
+      <Tiles size="large" colorIndex="light-2">
         {socialFeedCard}
         {blogPostCard}
       </Tiles>
     );
 
     var contentCardTiles = (
-      <Tiles size="large">
-       <ContentCard
+      <Tiles size="large" colorIndex="light-2">
+        <ContentCard
           direction="column"
           thumbnail="/docs/img/Case_Study_image.png"
           overline="Featured Post"
@@ -143,7 +150,7 @@ var ContentCardDoc = React.createClass({
     );
 
     var contentCardTilesMasonry = (
-      <Tiles size="large" masonry={true} numColumns={7}>
+      <Tiles size="large" masonry={true} numColumns={7} colorIndex="light-2">
         {blogPostCard}
         {featuredPostCard}
         {socialFeedCard}

--- a/src/develop/components/MarqueeDoc.js
+++ b/src/develop/components/MarqueeDoc.js
@@ -32,7 +32,7 @@ var MarqueeDoc = React.createClass({
   render: function() {
     var simpleMarquee = (
       <Marquee darkTheme={false}
-        backgroundImage="url(../img/MarqueeImage_051916_H.jpg)"
+        backgroundImage="../img/MarqueeImage_051916_H.jpg"
         headline="Accelerate your transformation with the cloud"
         subHeadline="HPE can help you benefit now from your right mix of cloud"
         link="http://www.grommet.io/docs/" />

--- a/src/examples/Examples.js
+++ b/src/examples/Examples.js
@@ -3,9 +3,11 @@
 var React = require('react');
 var Router = require('react-router');
 var Route = Router.Route;
+var Tiles = require('grommet/components/Tiles');
 var Box = require('grommet/components/Box');
 var Heading = require('grommet/components/Heading');
 var Paragraph = require('grommet/components/Paragraph');
+var SocialTwitterIcon = require('grommet/components/icons/base/SocialTwitter');
 var Marquee = require('../modules/Marquee');
 var ContentCard = require('../modules/ContentCard');
 var MarqueeParallax = require('../modules/MarqueeParallax');
@@ -41,6 +43,94 @@ var Examples = React.createClass({
     );
   },
 
+  _renderNewsFeed: function () {
+    var socialFeedCard = (
+      <ContentCard
+        direction="column"
+        overline="Social"
+        socialIcon={<SocialTwitterIcon />}
+        link="http://www.twitter.com">
+        <Heading tag="h2">Protect Your Digital Enterprise ipsum lorem dolores aeat el</Heading>
+      </ContentCard>
+    );
+
+    var blogPostCard = (
+      <ContentCard
+        direction="column"
+        overline="Featured Post"
+        link="http://www.twitter.com">
+        <Heading tag="h2">Protect Your Digital Enterprise ipsum lorem dolores aeat el</Heading>
+      </ContentCard>
+    );
+
+    var featuredPostCard = (
+      <ContentCard
+        thumbnail="/docs/img/Case_Study_image.png"
+        direction="column"
+        overline="Featured Post"
+        link="http://www.twitter.com">
+        <Heading tag="h2">Protect Your Digital Enterprise ipsum lorem dolores aeat el</Heading>
+      </ContentCard>
+    );
+
+    return (
+      <Box pad={{horizontal: 'large'}}>
+        <Tiles size="large" masonry={true} numColumns={7} colorIndex="light-2" justify="center">
+          {blogPostCard}
+          {featuredPostCard}
+          {socialFeedCard}
+          {socialFeedCard}
+          {blogPostCard}
+          {featuredPostCard}
+          {featuredPostCard}
+          {blogPostCard}
+        </Tiles>
+      </Box>
+    );
+  },
+
+  _renderContentCards: function () {
+    return (
+      <Box pad={{horizontal: 'large'}}>
+        <Tiles size="large" colorIndex="light-2" justify="center">
+          <ContentCard
+            direction="column"
+            thumbnail="/docs/img/Case_Study_image.png"
+            overline="Featured Post"
+            heading="Protect Your Digital Enterprise ipsum Learn More lorem dolores aeat"
+            description="It’s not an either/or world. It’s about finding the right platform for each app, workload and service. Learn how hybrid infrastructure can help you achieve cloud agility with traditional IT predictability. It’s not an either/or world. It’s about finding the right platform for each app, workload and service. Learn how hybrid infrastructure can help you achieve cloud agility with traditional IT predictability. It’s not an either/or world. It’s about finding the right platform for each app, workload and service. Learn how hybrid infrastructure can help you achieve cloud agility with traditional IT predictability. "
+            link="http://grommet.io"
+          />
+          <ContentCard
+            direction="column"
+            thumbnail="/docs/img/Video_image.png"
+            overline="Video - 4:27"
+            heading="Foundation Paraguay Empowers Microbusinesses"
+            description="See how Hewlett Packard Enterprise delivers mobile solutions to improve quality of life and help eliminate poverty in South America."
+            video={{
+              source: 'video/test.mp4',
+              type: 'mp4'
+            }}
+          />
+          <ContentCard
+            direction="column"
+            thumbnail="/docs/img/Case_Study_image.png"
+            overline="Featured Post"
+            heading="The Key Steps to Reducing Software Spend"
+            description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
+          />
+          <ContentCard
+            direction="column"
+            thumbnail="/docs/img/Case_Study_image.png"
+            overline="Featured Post"
+            heading="The Key Steps to Reducing Software Spend"
+            description="HPE Software Licensing and Management Solutions can help you optimize your software investments through control of complex negotiations and renewal processes"
+          />
+        </Tiles>
+      </Box>
+    );
+  },
+
   render: function () {
     return (
       <div>
@@ -51,10 +141,13 @@ var Examples = React.createClass({
               label: 'Examples',
               links: [{
                 label: 'Marquee',
-                href: '/docs/hpe/examples'
+                href: '/docs/hpe/develop/marquee'
               }, {
-                label: 'TBD',
-                href: '/docs/hpe/examples'
+                label: 'ContentCard',
+                href: '/docs/hpe/develop/contentcard'
+              }, {
+                label: 'Stack',
+                href: '/docs/hpe/develop/stack'
               }]
             }]
           } />
@@ -108,6 +201,7 @@ var Examples = React.createClass({
                 while leveraging your legacy investments
               </Paragraph>
               <ContentCard
+                direction="row"
                 thumbnail="/docs/img/Video_image.png"
                 overline="Video - 4:27"
                 heading="Foundation Paraguay Empowers Microbusinesses"
@@ -130,6 +224,7 @@ var Examples = React.createClass({
                 licensing compliance requirements
               </Paragraph>
               <ContentCard
+                direction="row"
                 thumbnail="/docs/img/Case_Study_image.png"
                 overline="Case Study"
                 heading="The Key Steps to Reducing Software Spend"
@@ -139,7 +234,13 @@ var Examples = React.createClass({
             </AccordionPanel>
           </Accordion>
         </Box>
+        <Box pad={{horizontal: 'large'}}><p><strong>Accordion with ContentCard, row direction</strong></p></Box>
         {this._loremIpsum()}
+        {this._renderContentCards()}
+        <Box pad={{horizontal: 'large'}}><p><strong>ContentCard with Tiles wrapper</strong></p></Box>
+        {this._loremIpsum()}
+        {this._renderNewsFeed()}
+        <Box pad={{horizontal: 'large'}}><p><strong>ContentCard with Tiles wrapper, masonry option</strong></p></Box>
       </div>
     );
   }

--- a/src/examples/Examples.js
+++ b/src/examples/Examples.js
@@ -138,7 +138,7 @@ var Examples = React.createClass({
           logoLink={'/docs/hpe/examples'}
           links={
             [{
-              label: 'Examples',
+              label: 'Documentation',
               links: [{
                 label: 'Marquee',
                 href: '/docs/hpe/develop/marquee'

--- a/src/modules/ContentCard.js
+++ b/src/modules/ContentCard.js
@@ -42,7 +42,7 @@ export default class ContentCard extends Component {
       return (
         <Box className="flex" pad={{between: 'large'}}>
           {children}
-          <Box align="end">
+          <Box className={`${CLASS_ROOT}__social-icon`} align="end">
             {socialIcon}
           </Box>
         </Box>
@@ -154,8 +154,10 @@ export default class ContentCard extends Component {
     }
 
     return (
-      <Tile className={classes} onClick={onContentCardClick} pad={pad || cardPad} {...tileProps}>
-        <Box className="flex" direction={direction} justify={cardJustify} full={cardFull}>
+      <Tile className={classes} onClick={onContentCardClick}
+        pad={pad || cardPad} {...tileProps}>
+        <Box className="flex" direction={direction} justify={cardJustify}
+          full={cardFull} colorIndex="light-1">
           {first}
           {second}
           {this._renderVideoMarkup()}

--- a/src/scss/_objects.content-card.scss
+++ b/src/scss/_objects.content-card.scss
@@ -1,9 +1,19 @@
+$card-hover-color: #EBEBEB;
+$social-icon-color: #1DA1F2;
+
 .content-card {
   @include media-query(palm) {
     padding: 0;
 
     &:not(:last-child) {
       border-bottom: 1px solid $border-color;
+    }
+  }
+
+  &__social-icon {
+    .grommetux-control-icon {
+      fill: $social-icon-color;
+      stroke: $social-icon-color;
     }
   }
 
@@ -104,13 +114,13 @@
     }
 
     &:hover > div {
-      background-color: rgba(246, 246, 246, 1);
+      background-color: $card-hover-color;
       color: $hover-text-color;
       cursor: pointer;
 
       .content-card__content {
         .grommetux-paragraph::after {
-          background: linear-gradient(to right, transparent, rgba(246, 246, 246, 1) 50%);
+          background: linear-gradient(to right, transparent, $card-hover-color 50%);
         }
       }
     }


### PR DESCRIPTION
**content card design tweaks:**
* updating default ContentCard container background to white
* adding social-icon className to box wrapping socialIcon to apply blue $social-icon-color to social icons
* changing ContentCard hover colors to darker gray to match designs more ($card-hover-color)

**doc updates:**
* updating ContentCardDoc examples to have light grey backgrounds 
* fixing broken Marquee image on MarqueeDoc
* adding ContentCard Tiles + NewsFeed examples to Examples page
* updating menu links to go to Marquee, ContentCard, and Stack docs pages
* updating Accordion example to use ContentCard row direction option

ContentCardDoc:
<img width="811" alt="screen shot 2016-08-09 at 4 26 34 pm" src="https://cloud.githubusercontent.com/assets/10161095/17539947/3b082954-5e4e-11e6-8aca-463c13b5b8b6.png">

Examples:
<img width="802" alt="screen shot 2016-08-09 at 4 27 31 pm" src="https://cloud.githubusercontent.com/assets/10161095/17539948/3b10cb4a-5e4e-11e6-825d-845f8786b0d8.png">
