### PR TITLE
Fix gulp dev issue for digital toolkit

### DIFF
--- a/grommet-toolbox.config.js
+++ b/grommet-toolbox.config.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 export default {
   base: '.',
-  publicPath: 'docs',
+  publicPath: '/docs',
   dist: path.resolve(__dirname, 'dist/'),
   copyAssets: [
     'src/index.html',


### PR DESCRIPTION
Fixes the issue where it opens a blank page when you run `gulp dev`