### PR TITLE
Full width containers for  social cards and news feed tiles

### DIFF
--- a/src/examples/Details.js
+++ b/src/examples/Details.js
@@ -459,7 +459,7 @@ export default class Details extends Component {
             </Paragraph>
             <Box margin={{top: 'large'}}>
               <Video>
-                <source src="/video/test.mp4" type="video/mp4" />
+                <source src="/docs/video/test.mp4" type="video/mp4" />
               </Video>
               <Paragraph margin="small">
                 Photos by Michael Blumenfeld

--- a/src/examples/Primary.js
+++ b/src/examples/Primary.js
@@ -135,9 +135,9 @@ const Primary = React.createClass({
 
     return (
       <Box className="columns-container" colorIndex="light-2"
-        pad={{horizontal: "large"}} size={{width: {max: "xxlarge"}}}>
+        pad={{horizontal: "large"}} size={{width: {max: "full"}}}>
         <Columns size="medium" justify="center" masonry={true}
-          maxCount={7} responsive={true}>
+          maxCount={3} responsive={true}>
           {blogPostCard}
           {featuredPostCard}
           {socialFeedCard1}
@@ -210,7 +210,7 @@ const Primary = React.createClass({
           </Box>
         </Box>
         <Box colorIndex="light-2" pad={{vertical: "large"}} align="center">
-          <Box size={{"width": "xxlarge"}} pad={{horizontal: "large"}}>
+          <Box align="start" size={{"width": "xxlarge"}} pad={{horizontal: "large"}}>
             <Heading tag="h2" strong={true}>
               Recent News
             </Heading>

--- a/src/examples/Sub.js
+++ b/src/examples/Sub.js
@@ -206,9 +206,7 @@ const SubPage = React.createClass({
           textSize="medium"
           link="http://www.grommet.io/docs/" />
         <Box colorIndex="light-2" pad={{vertical: "large"}} align="center">
-          <Box size={{"width": {"max": "xxlarge"}}}>
-            {this._renderCardTiles()}
-          </Box>
+          {this._renderCardTiles()}
         </Box>
       </div>
     );


### PR DESCRIPTION
allow card container (social cards on primary page, news feed on sub page) to expand full width.

![screen shot 2016-09-30 at 8 32 28 am](https://cloud.githubusercontent.com/assets/10161095/19002626/87018c70-86e8-11e6-997d-e69de6105c97.png)
