### PR TITLE
Example page fixes

### DIFF
--- a/src/examples/Details.js
+++ b/src/examples/Details.js
@@ -9,7 +9,7 @@ import Heading from 'grommet/components/Heading';
 import Paragraph from 'grommet/components/Paragraph';
 import Label from 'grommet/components/Label';
 import Anchor from 'grommet/components/Anchor';
-import WatchIcon from 'grommet/components/icons/base/Watch';
+import CirclePlayIcon from 'grommet/components/icons/base/CirclePlay';
 import Quote from 'grommet/components/Quote';
 import Image from 'grommet/components/Image';
 import Video from 'grommet/components/Video';
@@ -263,7 +263,7 @@ export default class Details extends Component {
                   aspernatur enim nulla.
                 </Paragraph>
                 <Box margin={{bottom: 'small'}}>
-                  <Anchor href="#" label="Watch the video" icon={<WatchIcon />} />
+                  <Anchor href="#" label="Watch the video" icon={<CirclePlayIcon />} />
                 </Box>
               </Box>
               <Box margin={{vertical: 'small'}}>
@@ -274,7 +274,7 @@ export default class Details extends Component {
                   aspernatur enim nulla.
                 </Paragraph>
                 <Box margin={{bottom: 'small'}}>
-                  <Anchor href="#" label="Watch the video" icon={<WatchIcon />} />
+                  <Anchor href="#" label="Watch the video" icon={<CirclePlayIcon />} />
                 </Box>
               </Box>
               <Heading tag="h3" margin="none">Media Coverage</Heading>

--- a/src/examples/Examples.js
+++ b/src/examples/Examples.js
@@ -18,7 +18,7 @@ var SocialTwitterIcon = require('grommet/components/icons/base/SocialTwitter');
 var SocialFacebookIcon = require('grommet/components/icons/base/SocialFacebook');
 var SocialLinkedinIcon = require('grommet/components/icons/base/SocialLinkedin');
 var LinkNextIcon = require('grommet/components/icons/base/LinkNext');
-var WatchIcon = require('grommet/components/icons/base/Watch');
+var CirclePlayIcon = require('grommet/components/icons/base/CirclePlay');
 var Marquee = require('../modules/Marquee');
 var MarqueeParallax = require('../modules/MarqueeParallax');
 var Header = require('./Header');
@@ -213,7 +213,7 @@ var Examples = React.createClass({
               source: 'video/test.mp4',
               type: 'mp4'
             }}
-            link={<Anchor href="#" label="Watch Now" icon={<WatchIcon />} />}
+            link={<Anchor href="#" label="Watch Now" icon={<CirclePlayIcon />} />}
           />
           <Card
             colorIndex="light-1"
@@ -422,7 +422,7 @@ var Examples = React.createClass({
                     source: 'video/test.mp4',
                     type: 'mp4'
                   }}
-                  link={<Anchor href="#" label="Watch Now" icon={<WatchIcon />} />}
+                  link={<Anchor href="#" label="Watch Now" icon={<CirclePlayIcon />} />}
                 />
               </Box>
             </AccordionPanel>
@@ -456,7 +456,7 @@ var Examples = React.createClass({
                     source: 'video/test.mp4',
                     type: 'mp4'
                   }}
-                  link={<Anchor href="#" label="Watch Now" icon={<WatchIcon />} />}
+                  link={<Anchor href="#" label="Watch Now" icon={<CirclePlayIcon />} />}
                 />
               </Box>
             </AccordionPanel>

--- a/src/examples/Header.js
+++ b/src/examples/Header.js
@@ -88,8 +88,13 @@ export default class HPEHeader extends Component {
           <Header appCentered={this.props.centered}
             justify="between" align={headerAlign} size="large"
             colorIndex={colorIndex}
-            pad={{horizontal: 'medium', vertical: headerVerticalPad, between: 'small'}} wrap={true}
-            external={this.props.external}>
+            pad={{
+              horizontal: 'medium',
+              vertical: headerVerticalPad,
+              between: 'small'
+            }}
+            wrap={true}
+          >
             <Box className={titleBoxClass} pad={titleBoxPad}>
               <Title onClick={this._onClickTitle}>
                 <Logo reverse={reverseLogo} />

--- a/src/examples/HeaderMenu.js
+++ b/src/examples/HeaderMenu.js
@@ -21,7 +21,7 @@ function renderMenuLinks (props) {
         {props.links.map((link, index) => {
           if (link.links && link.links.length > 0) {
             return (
-              <Menu key={index} label={link.label} align="stretch"
+              <Menu key={index} label={link.label}
                 colorIndex="dark"
                 dropColorIndex={props.colorIndex}
                 dropAlign={{top: 'top', left: 'left'}}>

--- a/src/examples/HeaderMenu.js
+++ b/src/examples/HeaderMenu.js
@@ -17,12 +17,12 @@ function renderMenuLinks (props) {
       separator={(props.external && props.responsive) ? 'top' : undefined}
       pad={{ horizontal: 'medium',vertical: 'none' }}>
       <Menu direction="row" inline={true}
-        dropColorIndex={props.colorIndex}
         label="Menu" dropAlign={{top: 'top', left: 'left'}}>
         {props.links.map((link, index) => {
           if (link.links && link.links.length > 0) {
             return (
               <Menu key={index} label={link.label} align="stretch"
+                colorIndex="dark"
                 dropColorIndex={props.colorIndex}
                 dropAlign={{top: 'top', left: 'left'}}>
                 {link.links.map((dropdownLink, linkIndex) =>

--- a/src/modules/Marquee.js
+++ b/src/modules/Marquee.js
@@ -174,7 +174,7 @@ export default class Marquee extends Component {
 
     if ((link || onClick) && overlayVideo) {
       separator = (
-        <Box direction="row" responsive="false">
+        <Box direction="row" responsive={false}>
           <Box pad={{ horizontal: 'small' }} separator="right" />
           <Box pad={{ horizontal: 'small' }} />
         </Box>

--- a/src/modules/Marquee.js
+++ b/src/modules/Marquee.js
@@ -8,7 +8,7 @@ import Image from 'grommet/components/Image';
 import Card from 'grommet/components/Card';
 import Headline from 'grommet/components/Headline';
 import Paragraph from 'grommet/components/Paragraph';
-import WatchIcon from 'grommet/components/icons/base/Watch';
+import CirclePlayIcon from 'grommet/components/icons/base/CirclePlay';
 import CloseIcon from 'grommet/components/icons/base/Close';
 
 const CLASS_ROOT = 'marquee';
@@ -168,7 +168,7 @@ export default class Marquee extends Component {
 
     if (overlayVideo) {
       watchNow = (
-        <Anchor onClick={this._onShowVideo} icon={<WatchIcon />} label="Watch Now" />
+        <Anchor onClick={this._onShowVideo} icon={<CirclePlayIcon />} label="Watch Now" />
       );
     }
 

--- a/src/scss/_objects.modules.scss
+++ b/src/scss/_objects.modules.scss
@@ -4,7 +4,6 @@
 
 .grommet.grommetux-app {
   position: relative;
-  overflow: hidden;
 
   .split--fixed > * {
     height: auto;


### PR DESCRIPTION
- Allow `examples` page to be scrollable.
- Invalid prop type fixes
- Fix Menu dropdown color
- Update `Watch` -> `CirclePlay` icon