### PR TITLE
Marquee + Examples.js update

### DIFF
--- a/src/examples/Examples.js
+++ b/src/examples/Examples.js
@@ -156,7 +156,7 @@ var Examples = React.createClass({
     return (
       <Box pad={{horizontal: 'large'}}>
         <Box colorIndex="light-2">
-          <Columns size="medium" masonry={true} maxCount={7} justify="center"
+          <Columns size="medium" masonry={true} maxCount={3} justify="center"
             responsive={true}>
             {blogPostCard}
             {featuredPostCard}
@@ -178,6 +178,7 @@ var Examples = React.createClass({
         <Tiles size="medium" colorIndex="light-2" justify="center">
           <Card
             colorIndex="light-1"
+            truncate={true}
             margin="small"
             contentPad="medium"
             onClick={this._onClickCard.bind(this, grommetPath)}
@@ -200,6 +201,7 @@ var Examples = React.createClass({
           />
           <Card
             colorIndex="light-1"
+            truncate={true}
             margin="small"
             contentPad="medium"
             direction="column"
@@ -217,6 +219,7 @@ var Examples = React.createClass({
           />
           <Card
             colorIndex="light-1"
+            truncate={true}
             margin="small"
             contentPad="medium"
             direction="column"
@@ -229,6 +232,7 @@ var Examples = React.createClass({
           />
           <Card
             colorIndex="light-1"
+            truncate={true}
             margin="small"
             contentPad="medium"
             direction="column"

--- a/src/modules/Marquee.js
+++ b/src/modules/Marquee.js
@@ -109,7 +109,8 @@ export default class Marquee extends Component {
       return (
         <Box containerClassName={CLASS_ROOT + "__background"}
           appCentered={true} pad={pad}
-          backgroundImage={`url(${backgroundImage})`} full={full} />
+          style={{backgroundImage: `url(${backgroundImage})`,
+            backgroundRepeat: "no-repeat"}} full={full} />
       );
     } else if (backgroundVideo) {
       return (

--- a/src/scss/_objects.marquee.scss
+++ b/src/scss/_objects.marquee.scss
@@ -8,6 +8,11 @@
     right: 0;
     left: 0;
     padding: 0;
+    background-position: center center;
+
+    @include media-query(palm) {
+      background-size: cover;
+    }
 
     &-video {
       overflow: hidden;

--- a/src/scss/_objects.marquee.scss
+++ b/src/scss/_objects.marquee.scss
@@ -9,10 +9,7 @@
     left: 0;
     padding: 0;
     background-position: center center;
-
-    @include media-query(palm) {
-      background-size: cover;
-    }
+    background-size: cover;
 
     &-video {
       overflow: hidden;


### PR DESCRIPTION
* update Marquee.js and styles to override grommet inline
* setting background-size to cover by default for all screen sizes
* updating Examples.js to allow only up to 3 columns, and truncate Tiles Card content.

Issue: https://github.com/grommet/hpe-digitaltoolkit/issues/146

override grommet inline styles preventing anchoring bg image to left:
<img width="409" alt="screen shot 2016-10-05 at 3 00 47 pm" src="https://cloud.githubusercontent.com/assets/10161095/19157371/d1e86140-8b80-11e6-8dd0-287f5cf02f8e.png">

PR fix:
<img width="520" alt="screen shot 2016-10-05 at 2 57 21 pm" src="https://cloud.githubusercontent.com/assets/10161095/19157405/e5c8dc1c-8b80-11e6-91cf-e66db5d870fd.png">