### PR TITLE
Fix race condition related to theme CSS (fixes #154)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,27 @@
   <meta name="mobile-web-app-capable" content="yes">
   <link rel="shortcut icon" type="image/png" href="/docs/img/shortcut-icon.png" />
   <link rel="apple-touch-icon" sizes="196x196" type="image/png" href="/docs/img/mobile-app-icon.png">
-  <link id="theme-link" href='/docs/vanilla.min.css' rel='stylesheet' type='text/css'>
+  <script>
+    (function(){
+      // Note: this is only to get themes working in dev mode.  In prod, the theme link tag
+      // is generated serverside in server/docs.js
+
+      var themeGroups = /docs\/([^\/]+)\/?/.exec(window.location.pathname);
+      var defaultTheme = 'vanilla';
+      var theme = '';
+      if (themeGroups && themeGroups.length > 1) {
+        theme = themeGroups[1];
+        var possibleThemes = 'aruba,hpe,hpinc';
+        if (possibleThemes.indexOf(theme) === -1) {
+          theme = '';
+        }
+      }
+
+      // Write out CSS link tag synchronously/blocking based on url path.
+      var themeUrl = '/docs/' + (theme === '' ? defaultTheme : theme) + '.min.css';
+      document.write('<link href="' + themeUrl + '" rel="stylesheet" type="text/css">');
+    })();
+  </script>
   <style>
   body.loading {margin: 0px; width: 100vw; height: 100vh;
     background-image: radial-gradient(circle at 50% 15%, #fff, #fff 30%, #ccc);

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,9 @@ var ReactDOM = require('react-dom');
 var Router = require('react-router').Router;
 var createHistory = require('history').createHistory;
 
+// Get rootPath based on theme.  No need to inject theme CSS link tag here, since it
+// is injected serverside.
 var themeGroups = /docs\/([^\/]+)\/?/.exec(window.location.pathname);
-
 var theme = '';
 if (themeGroups && themeGroups.length > 1) {
   theme = themeGroups[1];
@@ -25,11 +26,6 @@ if (themeGroups && themeGroups.length > 1) {
     theme = '';
   }
 }
-
-var themeLink = document.getElementById('theme-link');
-var themeUrl = '/docs/' + (theme === '' ? 'vanilla' : theme) + '.min.css';
-themeLink.setAttribute('href', themeUrl);
-
 var rootPath = '/docs/' + (theme === '' ? '' : theme + '/');
 
 var routes = require('./routes')(rootPath);


### PR DESCRIPTION
* Fixes #154

It looks like theme handling was added to `index.js` for themes to function properly in dev mode (`index.html`), but unfortunately this code is also redundantly run in prod, where theme CSS is already handled serverside (`index.ejs`).  In prod, this resulted in the theme CSS being injected twice: once in synchronous CSS in the page `head`, and again asynchronously in clientside code.

This caused cross-browser styling inconsistencies in components that ultimately rely on `window.getComputedStyle` (particularly Grommet `Box`, which depends on the core library's `hasDarkBackground` in utils/DOM), which assumes that all CSS has already loaded and has been applied to the page.  Which in this case isn't guaranteed, since CSS is being loaded async in the second instance.

For instance, Chrome reported elements with a background color of `rgb(255,255,255)` whereas IE reported elements with a background color of `transparent`.  This code originally changed the `href` of the theme CSS `link` tag, and different browsers handled this in different ways.  IE immediately resets the first CSS that gets applied (and thus `getComputedStyle` reported all background colors as `transparent`), whereas other browsers still retained the styles until the new stylesheet loaded.  This ultimately lead to inconsistent styling as reported in #154.

This fix moves the clientside theme injection into the dev-only code (`index.html`) and injects it synchronously in the document `head` (yeah, ew `document.write`, but that's what we want it to do in this case).