### PR TITLE
Fix video thumbnail animation (closes #158)

### DIFF
--- a/src/examples/Examples.js
+++ b/src/examples/Examples.js
@@ -406,7 +406,7 @@ var Examples = React.createClass({
               }
               a11yTitle='Enterprise Mobility Services'
             >
-              <Box pad="medium">
+              <Box pad="medium" size="full">
                 <Heading tag="h3" margin="none">
                   Empower your employees while ensuring your workplace remains enterprise grade, scalable and secure.
                 </Heading>
@@ -416,6 +416,7 @@ var Examples = React.createClass({
                   while leveraging your legacy investments
                 </Paragraph>
                 <Card
+                  size="full"
                   margin="small"
                   contentPad="medium"
                   direction="row"


### PR DESCRIPTION
This fixes the issue seen with the `Accordion` animation on Firefox and Edge (#158)

**Note: grommet/grommet#1006 must also be merged for this to work.**

Tested on the following:
* Firefox 49 on OSX
* Edge on Windows 10
* Chrome 54 on OSX

# Before (Firefox)
![before](https://cloud.githubusercontent.com/assets/120596/19674264/c20bb802-9a3b-11e6-8b83-a82c0b690ad9.gif)

# After (Firefox)
![after](https://cloud.githubusercontent.com/assets/120596/19674266/c52bd224-9a3b-11e6-894b-142f68a63ee3.gif)
